### PR TITLE
Bugfix:  Sub-table memory corruption

### DIFF
--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -144,8 +144,12 @@ describe AMQ::Protocol::Table do
     t1["x-delay"]?.should be_nil
     t1.to_h.should eq({"x-stream-offset" => 1i64})
   end
+end
 
-  it "should not overwrite other tables memory when reassigning values in a Table" do
+# Verifies bugfix for Sub-table memory corruption
+# https://github.com/cloudamqp/amq-protocol.cr/pull/14
+describe "should not overwrite sub-tables memory when reassigning values in a Table" do
+  it "when reassigning a Table" do
     parent_table = AMQ::Protocol::Table.new
     child_table = AMQ::Protocol::Table.new({"a": "b"})
     parent_table["table"] = child_table
@@ -158,5 +162,22 @@ describe AMQ::Protocol::Table do
 
     # Verify that read_table wasn't modified by reassignment of "table"
     table_from_io.should eq child_table
+  end
+
+  it "when reassigning a string" do
+    parent_table = AMQ::Protocol::Table.new
+    child_table = AMQ::Protocol::Table.new({"abc": "123"})
+
+    parent_table["foo"] = "bar"
+    parent_table["tbl"] = child_table
+
+    # Read child_table from io
+    read_table = parent_table["tbl"].as(AMQ::Protocol::Table)
+
+    # Overwrite string "foo" in parent_table
+    parent_table["foo"] = "foooo"
+
+    # Verify that read_table wasn't modified by reassignment of "foo"
+    read_table.should eq child_table
   end
 end

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -145,21 +145,18 @@ describe AMQ::Protocol::Table do
     t1.to_h.should eq({"x-stream-offset" => 1i64})
   end
 
-  it "can handle nestled Tables" do
+  it "should not overwrite other tables memory when reassigning values in a Table" do
     parent_table = AMQ::Protocol::Table.new
-    child_table = AMQ::Protocol::Table.new({"abc": "123"})
-    parent_table["tbl"] = child_table
+    child_table = AMQ::Protocol::Table.new({"a": "b"})
+    parent_table["table"] = child_table
 
-    read_table = parent_table["tbl"].as(AMQ::Protocol::Table)
-    parent_table.delete("tbl")
+    # Read child_table from io
+    table_from_io = parent_table["table"].as(AMQ::Protocol::Table)
 
-    parent_table["foo"] = "bar"
-    parent_table["tbl"] = read_table
+    # Overwrite child_table data in parent_table
+    parent_table["table"] = "foo"
 
-    comparison_table = AMQ::Protocol::Table.new({
-      "tbl": AMQ::Protocol::Table.new({"abc": "123"}),
-      "foo": "bar",
-    })
-    parent_table.should eq comparison_table
+    # Verify that read_table wasn't modified by reassignment of "table"
+    table_from_io.should eq child_table
   end
 end

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -146,7 +146,7 @@ describe AMQ::Protocol::Table do
   end
 
   it "can handle nestled Tables" do
-    parent_table = AMQ::Protocol::Table.new()
+    parent_table = AMQ::Protocol::Table.new
     child_table = AMQ::Protocol::Table.new({"abc": "123"})
     parent_table["tbl"] = child_table
 
@@ -158,7 +158,7 @@ describe AMQ::Protocol::Table do
 
     comparison_table = AMQ::Protocol::Table.new({
       "tbl": AMQ::Protocol::Table.new({"abc": "123"}),
-      "foo": "bar"
+      "foo": "bar",
     })
     parent_table.should eq comparison_table
   end

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -144,4 +144,22 @@ describe AMQ::Protocol::Table do
     t1["x-delay"]?.should be_nil
     t1.to_h.should eq({"x-stream-offset" => 1i64})
   end
+
+  it "can handle nestled Tables" do
+    parent_table = AMQ::Protocol::Table.new()
+    child_table = AMQ::Protocol::Table.new({"abc": "123"})
+    parent_table["tbl"] = child_table
+
+    read_table = parent_table["tbl"].as(AMQ::Protocol::Table)
+    parent_table.delete("tbl")
+
+    parent_table["foo"] = "bar"
+    parent_table["tbl"] = read_table
+
+    comparison_table = AMQ::Protocol::Table.new({
+      "tbl": AMQ::Protocol::Table.new({"abc": "123"}),
+      "foo": "bar"
+    })
+    parent_table.should eq comparison_table
+  end
 end

--- a/src/amq/protocol/table.cr
+++ b/src/amq/protocol/table.cr
@@ -194,9 +194,15 @@ module AMQ
         size ||= UInt32.from_io(io, format)
         case io
         when IO::Memory
-          bytes = io.to_slice[io.pos, size]
-          io.pos += size
-          self.new(IO::Memory.new(bytes, writeable: false))
+          if io.@writeable
+            mem = IO::Memory.new(size)
+            IO.copy(io, mem, size)
+            self.new(mem)
+          else
+            bytes = io.to_slice[io.pos, size]
+            io.pos += size
+            self.new(IO::Memory.new(bytes, writeable: false))
+          end
         else
           mem = IO::Memory.new(size)
           IO.copy(io, mem, size)


### PR DESCRIPTION
Fixes a bug where nestling a Table in another Table (for example x-death headers) caused them to share memory, even though it was writeable. This caused corruption when re-assigning values. See the spec for replication. 