### PR TITLE
Table#delete and Table#has_key? argument must be string

### DIFF
--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -116,6 +116,7 @@ describe AMQ::Protocol::Table do
   it "supports #delete" do
     t1 = AMQ::Protocol::Table.new({a: 1, b: "foo"})
     t1.delete("a").should eq 1
+    t1["a"]?.should be_nil
     t1.to_h.should eq({"b" => "foo"})
   end
 
@@ -135,8 +136,12 @@ describe AMQ::Protocol::Table do
 
     it "supports NamedTuple" do
       t1 = AMQ::Protocol::Table.new({a: 1, b: "foo"})
-      t1.merge!({c: nil})
-      t1.to_h.should eq({"a" => 1, "b" => "foo", "c" => nil})
+      t1.merge!({c: nil, b: "bar"})
+      t1["a"].should eq 1
+      t1["b"].should eq "bar"
+      t1["c"].should eq nil
+      t1.size.should eq 3
+      t1.to_h.should eq({"a" => 1, "b" => "bar", "c" => nil})
     end
 
     it "supports Hash(String, Field)" do

--- a/src/amq/protocol/table.cr
+++ b/src/amq/protocol/table.cr
@@ -55,11 +55,6 @@ module AMQ
         yield
       end
 
-      @[Deprecated("key must be string")]
-      def has_key?(key : Symbol)
-        has_key?(key.to_s)
-      end
-
       def has_key?(key : String) : Bool
         @io.rewind
         while @io.pos < @io.bytesize
@@ -70,6 +65,11 @@ module AMQ
           end
         end
         false
+      end
+
+      @[Deprecated("key must be string")]
+      def has_key?(key)
+        has_key?(key.to_s)
       end
 
       def each(& : (String, Field) -> Nil)
@@ -167,11 +167,6 @@ module AMQ
         true
       end
 
-      @[Deprecated("key must be string")]
-      def delete(key : Symbol)
-        delete(key.to_s)
-      end
-
       def delete(key : String)
         ensure_writeable
         @io.rewind
@@ -187,6 +182,11 @@ module AMQ
           skip_field
         end
         nil
+      end
+
+      @[Deprecated("key must be string")]
+      def delete(key)
+        delete(key.to_s)
       end
 
       def to_io(io, format) : Nil

--- a/src/amq/protocol/table.cr
+++ b/src/amq/protocol/table.cr
@@ -55,7 +55,12 @@ module AMQ
         yield
       end
 
-      def has_key?(key) : Bool
+      @[Deprecated("key must be string")]
+      def has_key?(key : Symbol)
+        has_key?(key.to_s)
+      end
+
+      def has_key?(key : String) : Bool
         @io.rewind
         while @io.pos < @io.bytesize
           if key == ShortString.from_io(@io)
@@ -162,7 +167,12 @@ module AMQ
         true
       end
 
-      def delete(key)
+      @[Deprecated("key must be string")]
+      def delete(key : Symbol)
+        delete(key.to_s)
+      end
+
+      def delete(key : String)
         ensure_writeable
         @io.rewind
         while @io.pos < @io.bytesize
@@ -235,7 +245,7 @@ module AMQ
         ensure_writeable
         @io.rewind
         other.each do |key, value|
-          delete(key)
+          delete(key.to_s)
           @io.skip_to_end
           @io.write_bytes(ShortString.new(key.to_s))
           write_field(value)


### PR DESCRIPTION
In public methods `key` is typed as `String`, except for `delete` and `has_key?`. This will type `key` as `String` and adds deprecated method overloads that supports "any" key.

That any type was accepted as key in `delete` caused `merge!` with `NamedTuple` to break, because `delete` didn't delete old values because of a symbol-string comparison in `delete` always was false.

Since all methods except for `delete` and `has_key?` types `key` to `String` it's reasonable to do it in them as well.