### PR TITLE
Fix Exchange::Bind frame bytesize calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Exchange::Bind frame bytesize calculation that incorrectly included extra bytes, which could cause protocol errors when binding exchanges
+
 ## [1.1.15] - 2025-05-20
 
 ### Added

--- a/spec/frame_spec.cr
+++ b/spec/frame_spec.cr
@@ -17,4 +17,17 @@ describe AMQ::Protocol::Frame::Method::Basic::Get do
     frame.to_io(io, IO::ByteFormat::SystemEndian)
     frame.to_slice.should eq io.to_slice
   end
+
+  it "can encode Exchange::Bind frame with correct bytesize" do
+    destination = "my_destination"
+    source = "my_source"
+    routing_key = "my_routing_key"
+    arguments = AMQ::Protocol::Table.new
+    frame = AMQ::Protocol::Frame::Exchange::Bind.new(1u16, 0u16, destination, source, routing_key, false, arguments)
+    # Method body size: reserved1 + destination + source + routing_key + no_wait + arguments
+    method_body_size = 2 + 1 + destination.bytesize + 1 + source.bytesize + 1 + routing_key.bytesize + 1 + arguments.bytesize
+    # Total frame size includes 4 bytes for class_id + method_id
+    expected_bytesize = method_body_size + 4
+    frame.bytesize.should eq expected_bytesize
+  end
 end


### PR DESCRIPTION
Fixes a bug in the Exchange::Bind frame bytesize calculation that was incorrectly including an extra 2 bytes.