### PR TITLE
Fix compatibility with AMQP 0-9 field types

### DIFF
--- a/src/amq/protocol/table.cr
+++ b/src/amq/protocol/table.cr
@@ -373,9 +373,11 @@ module AMQ
         when 'B' then @io.skip(sizeof(UInt8))
         when 's' then @io.skip(sizeof(Int16))
         when 'u' then @io.skip(sizeof(UInt16))
+        when 'U' then @io.skip(sizeof(Int16)) # Compatibility with AMQP 0-9
         when 'I' then @io.skip(sizeof(Int32))
         when 'i' then @io.skip(sizeof(UInt32))
         when 'l' then @io.skip(sizeof(Int64))
+        when 'L' then @io.skip(sizeof(Int64)) # Compatibility with AMQP 0-9
         when 'f' then @io.skip(sizeof(Float32))
         when 'd' then @io.skip(sizeof(Float64))
         when 'S' then @io.skip(UInt32.from_io(@io, BYTEFORMAT))
@@ -397,9 +399,11 @@ module AMQ
         when 'B' then UInt8.from_io(@io, BYTEFORMAT)
         when 's' then Int16.from_io(@io, BYTEFORMAT)
         when 'u' then UInt16.from_io(@io, BYTEFORMAT)
+        when 'U' then Int16.from_io(@io, BYTEFORMAT) # Compatibility with AMQP 0-9
         when 'I' then Int32.from_io(@io, BYTEFORMAT)
         when 'i' then UInt32.from_io(@io, BYTEFORMAT)
         when 'l' then Int64.from_io(@io, BYTEFORMAT)
+        when 'L' then Int64.from_io(@io, BYTEFORMAT) # Compatibility with AMQP 0-9
         when 'f' then Float32.from_io(@io, BYTEFORMAT)
         when 'd' then Float64.from_io(@io, BYTEFORMAT)
         when 'S' then LongString.from_io(@io, BYTEFORMAT)


### PR DESCRIPTION
This PR fixes a crash that occurred when loading queue definitions containing AMQP 0-9 field types. LavinMQ would encounter an "Unknown field type '76'" error and fail during vhost initialization.

The issue stems from differences between AMQP 0-9 and 0-9-1 protocol versions. While functionally equivalent, these versions use different type codes for integer fields in tables. Specifically, AMQP 0-9 uses 'L' (0x4C) for 64-bit signed integers and 'U' (0x55) for 16-bit unsigned integers, whereas AMQP 0-9-1 uses 'l' and 's' respectively.

This change adds support for the 'L' and 'U' field types in both the skip_field and read_field methods, treating them identically to their lowercase counterparts. 