### PR TITLE
Don't raise exception if frame size > actual frame

### DIFF
--- a/src/amq/protocol/stream.cr
+++ b/src/amq/protocol/stream.cr
@@ -119,9 +119,10 @@ module AMQ
         else
           raise IO::EOFError.new("Unexpected EOF while reading frame-end")
         end
-        if @frame_remaining != 0
-          raise Protocol::Error::FrameSizeError.new("Frame not fully read, #{@frame_remaining} bytes remaining")
-        end
+        # Could ensure the frame was fully read, but might cause issues with some implementations
+        # if @frame_remaining != 0
+        # raise Protocol::Error::InvalidFrameEnd.new("Frame not fully read, #{@frame_remaining} bytes remaining")
+        # end
       end
     end
   end


### PR DESCRIPTION
While sound, it causes issues with some protocol implementations, for instance this library increased the exchange.bind frame with 2 bytes before version 1.1.16.