### PR TITLE
Add support for nested `#each`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed bug in `Table#==` that made `Table.new({a: nil}) == Table.new({b: "foo"})`
 
+### Added
+- `Table#each` supports nesting. Before the inner `#each` would interfer with the outer.
+
 ## [1.1.20] - 2025-11-22
 
 ### Fixed

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -242,6 +242,15 @@ describe AMQ::Protocol::Table do
       end
       i.should eq 9
     end
+
+    it "should raise initial position is larger than bytesize after iteration" do
+      t1 = AMQ::Protocol::Table.new({a: 1, b: 2, c: 3})
+      expect_raises(AMQ::Protocol::Error, %r{modified}) do
+        t1.each do
+          t1.delete "b"
+        end
+      end
+    end
   end
 
   describe "#any?(&)" do

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -226,9 +226,9 @@ describe AMQ::Protocol::Table do
       t1 = AMQ::Protocol::Table.new({c: 1, b: 2, a: 3})
       i = 0
       expected = {"c", "b", "a"}
-      t1.each do |k, v|
-        k.should eq expected[i]
-        v.should eq(i += 1)
+      t1.each do |key, value|
+        key.should eq expected[i]
+        value.should eq(i += 1)
       end
     end
 
@@ -252,15 +252,15 @@ describe AMQ::Protocol::Table do
 
     it "should return false when block return false for all invocations" do
       t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3})
-      t1.any? { |k, v| v == 4 }.should be_false
+      t1.any? { |_, value| value == 4 }.should be_false
     end
 
     it "should return true and stop iteration if block returns true" do
       t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3, "d": 4})
       i = 0
-      t1.any? do |k, v|
+      t1.any? do |_, value|
         i += 1
-        v == 3
+        value == 3
       end.should be_true
       i.should eq 3
     end
@@ -274,15 +274,15 @@ describe AMQ::Protocol::Table do
 
     it "should return true when block return true for all invocations" do
       t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3})
-      t1.all? { |k, v| v.as(Int32) < 100 }.should be_true
+      t1.all? { |_, value| value.as(Int32) < 100 }.should be_true
     end
 
     it "should return false and stop iteration if block returns true" do
       t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3, "d": 4})
       i = 0
-      t1.all? do |k, v|
+      t1.all? do |_, value|
         i += 1
-        v.as(Int32) < 3
+        value.as(Int32) < 3
       end.should be_false
       i.should eq 3
     end

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -215,6 +215,23 @@ describe AMQ::Protocol::Table do
   end
 
   describe "#each" do
+    it "should not call block if empty" do
+      t1 = AMQ::Protocol::Table.new
+      called = false
+      t1.each { called = true }
+      called.should be_false
+    end
+
+    it "should iterate keys in the order they are added" do
+      t1 = AMQ::Protocol::Table.new({c: 1, b: 2, a: 3})
+      i = 0
+      expected = {"c", "b", "a"}
+      t1.each do |k, v|
+        k.should eq expected[i]
+        v.should eq(i += 1)
+      end
+    end
+
     it "can be nested" do
       t1 = AMQ::Protocol::Table.new({a: 1, b: 2, c: 3})
       i = 0

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -213,40 +213,97 @@ describe AMQ::Protocol::Table do
       (t2 == t1).should be_false
     end
   end
-end
 
-# Verifies bugfix for Sub-table memory corruption
-# https://github.com/cloudamqp/amq-protocol.cr/pull/14
-describe "should not overwrite sub-tables memory when reassigning values in a Table" do
-  it "when reassigning a Table" do
-    parent_table = AMQ::Protocol::Table.new
-    child_table = AMQ::Protocol::Table.new({"a": "b"})
-    parent_table["table"] = child_table
-
-    # Read child_table from io
-    table_from_io = parent_table["table"].as(AMQ::Protocol::Table)
-
-    # Overwrite child_table data in parent_table
-    parent_table["table"] = "foo"
-
-    # Verify that read_table wasn't modified by reassignment of "table"
-    table_from_io.should eq child_table
+  describe "#each" do
+    it "can be nested" do
+      t1 = AMQ::Protocol::Table.new({a: 1, b: 2, c: 3})
+      i = 0
+      t1.each do
+        t1.each do
+          i += 1
+        end
+      end
+      i.should eq 9
+    end
   end
 
-  it "when reassigning a string" do
-    parent_table = AMQ::Protocol::Table.new
-    child_table = AMQ::Protocol::Table.new({"abc": "123"})
+  describe "#any?(&)" do
+    it "should return false when empty" do
+      t1 = AMQ::Protocol::Table.new
+      t1.any? { }.should be_false
+    end
 
-    parent_table["foo"] = "bar"
-    parent_table["tbl"] = child_table
+    it "should return false when block return false for all invocations" do
+      t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3})
+      t1.any? { |k, v| v == 4 }.should be_false
+    end
 
-    # Read child_table from io
-    read_table = parent_table["tbl"].as(AMQ::Protocol::Table)
+    it "should return true and stop iteration if block returns true" do
+      t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3, "d": 4})
+      i = 0
+      t1.any? do |k, v|
+        i += 1
+        v == 3
+      end.should be_true
+      i.should eq 3
+    end
+  end
 
-    # Overwrite string "foo" in parent_table
-    parent_table["foo"] = "foooo"
+  describe "#all?(&)" do
+    it "should return true when empty" do
+      t1 = AMQ::Protocol::Table.new
+      t1.all? { }.should be_true
+    end
 
-    # Verify that read_table wasn't modified by reassignment of "foo"
-    read_table.should eq child_table
+    it "should return true when block return true for all invocations" do
+      t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3})
+      t1.all? { |k, v| v.as(Int32) < 100 }.should be_true
+    end
+
+    it "should return false and stop iteration if block returns true" do
+      t1 = AMQ::Protocol::Table.new({"a": 1, "b": 2, "c": 3, "d": 4})
+      i = 0
+      t1.all? do |k, v|
+        i += 1
+        v.as(Int32) < 3
+      end.should be_false
+      i.should eq 3
+    end
+  end
+
+  # Verifies bugfix for Sub-table memory corruption
+  # https://github.com/cloudamqp/amq-protocol.cr/pull/14
+  describe "should not overwrite sub-tables memory when reassigning values in a Table" do
+    it "when reassigning a Table" do
+      parent_table = AMQ::Protocol::Table.new
+      child_table = AMQ::Protocol::Table.new({"a": "b"})
+      parent_table["table"] = child_table
+
+      # Read child_table from io
+      table_from_io = parent_table["table"].as(AMQ::Protocol::Table)
+
+      # Overwrite child_table data in parent_table
+      parent_table["table"] = "foo"
+
+      # Verify that read_table wasn't modified by reassignment of "table"
+      table_from_io.should eq child_table
+    end
+
+    it "when reassigning a string" do
+      parent_table = AMQ::Protocol::Table.new
+      child_table = AMQ::Protocol::Table.new({"abc": "123"})
+
+      parent_table["foo"] = "bar"
+      parent_table["tbl"] = child_table
+
+      # Read child_table from io
+      read_table = parent_table["tbl"].as(AMQ::Protocol::Table)
+
+      # Overwrite string "foo" in parent_table
+      parent_table["foo"] = "foooo"
+
+      # Verify that read_table wasn't modified by reassignment of "foo"
+      read_table.should eq child_table
+    end
   end
 end

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -243,7 +243,7 @@ describe AMQ::Protocol::Table do
       i.should eq 9
     end
 
-    it "should raise initial position is larger than bytesize after iteration" do
+    it "should raise if initial position is larger than bytesize after iteration" do
       t1 = AMQ::Protocol::Table.new({a: 1, b: 2, c: 3})
       expect_raises(AMQ::Protocol::Error, %r{modified}) do
         t1.each do

--- a/src/amq/protocol/table.cr
+++ b/src/amq/protocol/table.cr
@@ -271,7 +271,12 @@ module AMQ
         end
       ensure
         if p = pos
-          @io.pos = {p, @io.bytesize}.min
+          if p > @io.bytesize
+            err = "Initial position larger than bytesize. Has the Table been " \
+                  " modified during iteration?"
+            raise AMQ::Protocol::Error.new err
+          end
+          @io.pos = p
         end
       end
 


### PR DESCRIPTION
Because `#each` calls `#rewind` on the underlying IO it wasn't possible to nest each calls, because the inner `#each` will ruin the position for the outer one.

This PR change so position is restored to what it was before `#each` was called. This is also added other read methods doing iterations such as `#any?` and `#all?`.