### PR TITLE
Bugfix (regression): dont raise on too large pos

### DIFF
--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -254,15 +254,6 @@ describe AMQ::Protocol::Table do
       end
       i.should eq 9
     end
-
-    it "should raise if initial position is larger than bytesize after iteration" do
-      t1 = AMQ::Protocol::Table.new({a: 1, b: 2, c: 3})
-      expect_raises(AMQ::Protocol::Error, %r{modified}) do
-        t1.each do
-          t1.delete "b"
-        end
-      end
-    end
   end
 
   describe "#any?(&)" do

--- a/src/amq/protocol/table.cr
+++ b/src/amq/protocol/table.cr
@@ -287,11 +287,6 @@ module AMQ
         end
       ensure
         if p = pos
-          if p > @io.bytesize
-            err = "Initial position larger than bytesize. Has the Table been " \
-                  " modified during iteration?"
-            raise AMQ::Protocol::Error.new err
-          end
           @io.pos = p
         end
       end


### PR DESCRIPTION
#31 introduced a bug where an method call triggering an iteration raised an error. This happened if e.g. a `delete` had been done before the iteration.

This PR will remove the position validation done before restoring the position.