### PR TITLE
Preserve heartbeat frame channel during decode

### DIFF
--- a/spec/frame_spec.cr
+++ b/spec/frame_spec.cr
@@ -56,19 +56,18 @@ describe AMQ::Protocol::Frame::Heartbeat do
     end
   end
 
-  it "rejects heartbeat frames with non-zero channel" do
+  it "decodes heartbeat frames with non-zero channel" do
     io = IO::Memory.new
     format = IO::ByteFormat::NetworkEndian
 
-    # Manually construct a malformed heartbeat with non-zero channel
+    # Preserve the channel so consumers can classify the frame.
     io.write_byte(8_u8)           # Heartbeat frame type
-    io.write_bytes(5_u16, format) # Channel 5 (invalid for heartbeat!)
+    io.write_bytes(5_u16, format) # Channel 5
     io.write_bytes(0_u32, format) # Size 0
     io.write_byte(206_u8)         # Frame end marker
     io.rewind
 
-    expect_raises(AMQ::Protocol::Error::FrameDecode, /Heartbeat frame channel must be 0, got 5/) do
-      AMQ::Protocol::Stream.new(io).next_frame
-    end
+    frame = AMQ::Protocol::Stream.new(io).next_frame.as(AMQ::Protocol::Frame::Heartbeat)
+    frame.channel.should eq 5
   end
 end

--- a/src/amq/protocol/frames.cr
+++ b/src/amq/protocol/frames.cr
@@ -201,9 +201,8 @@ module AMQ
           TYPE
         end
 
-        def initialize
-          @channel = 0_u16
-          @bytesize = 0_u32
+        def initialize(channel : UInt16 = 0_u16)
+          super(channel, 0_u32)
         end
 
         def to_io(io, format)
@@ -211,13 +210,10 @@ module AMQ
         end
 
         def self.from_io(channel, size, io, format)
-          unless channel.zero?
-            raise Protocol::Error::FrameDecode.new("Heartbeat frame channel must be 0, got #{channel}")
-          end
           unless size.zero?
             raise Protocol::Error::FrameDecode.new("Heartbeat frame size must be 0, got #{size}")
           end
-          new
+          new(channel)
         end
       end
 


### PR DESCRIPTION
## Summary

- stop rejecting heartbeat frames only because they use a non-zero channel
- keep validating heartbeat frame size as a decode error
- preserve the decoded heartbeat channel so consumers can classify the frame

Related to cloudamqp/lavinmq#1991.

This supports the LavinMQ fix where a heartbeat on a non-zero channel should be reported as `UNEXPECTED_FRAME` rather than `FRAME_ERROR`.

## Testing

- `crystal tool format --check src/amq/protocol/frames.cr spec/frame_spec.cr`
- `git diff --check`
- `crystal spec -Dpreview_mt -Dexecution_context`
