### PR TITLE
Add Table#has_entry? for allocation-free entry comparison

### DIFF
--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -414,6 +414,74 @@ describe AMQ::Protocol::Table do
     t1.to_h.should eq({"x-stream-offset" => 1i64})
   end
 
+  describe "#has_entry?" do
+    it "returns true when key is present and value is equal" do
+      t1 = AMQ::Protocol::Table.new({str: "foo", int: 42, bool: true, nilval: nil, float: 1.5})
+      t1.has_entry?("str", "foo").should be_true
+      t1.has_entry?("int", 42).should be_true
+      t1.has_entry?("bool", true).should be_true
+      t1.has_entry?("nilval", nil).should be_true
+      t1.has_entry?("float", 1.5).should be_true
+    end
+
+    it "returns false when key is present but value differs" do
+      t1 = AMQ::Protocol::Table.new({str: "foo", int: 42, bool: true})
+      t1.has_entry?("str", "bar").should be_false
+      t1.has_entry?("str", "fo").should be_false
+      t1.has_entry?("int", 43).should be_false
+      t1.has_entry?("bool", false).should be_false
+    end
+
+    it "returns false when key is absent" do
+      t1 = AMQ::Protocol::Table.new({a: 1})
+      t1.has_entry?("b", 1).should be_false
+      AMQ::Protocol::Table.new.has_entry?("a", 1).should be_false
+    end
+
+    it "compares numerics across types" do
+      t1 = AMQ::Protocol::Table.new({a: 1_i64, b: 1_u8})
+      t1.has_entry?("a", 1_i32).should be_true
+      t1.has_entry?("b", 1_i64).should be_true
+      t1.has_entry?("a", 2_i32).should be_false
+    end
+
+    it "returns false on type mismatch" do
+      t1 = AMQ::Protocol::Table.new({str: "1", bytes: "foo".to_slice, int: 1})
+      t1.has_entry?("str", 1).should be_false
+      t1.has_entry?("bytes", "foo").should be_false
+      t1.has_entry?("int", "1").should be_false
+    end
+
+    it "compares nested table values" do
+      t1 = AMQ::Protocol::Table.new({nested: {"a" => 1}})
+      t1.has_entry?("nested", AMQ::Protocol::Table.new({a: 1})).should be_true
+      t1.has_entry?("nested", AMQ::Protocol::Table.new({a: 2})).should be_false
+    end
+
+    it "compares against the first occurrence when keys are duplicated" do
+      first = AMQ::Protocol::Table.new({a: "first"})
+      second = AMQ::Protocol::Table.new({a: "second", b: 1})
+      bytes = Bytes.new(first.to_slice.size + second.to_slice.size)
+      first.to_slice.copy_to(bytes)
+      second.to_slice.copy_to(bytes + first.to_slice.size)
+      degenerate = AMQ::Protocol::Table.new(bytes)
+      degenerate["a"].should eq "first" # fetch semantics
+      degenerate.has_entry?("a", "first").should be_true
+      degenerate.has_entry?("a", "second").should be_false
+      degenerate.has_entry?("b", 1).should be_true
+    end
+
+    it "behaves like has_key? && fetch == value" do
+      t1 = AMQ::Protocol::Table.new({str: "foo", int: 42, nilval: nil})
+      {"str", "int", "nilval", "missing"}.each do |key|
+        {"foo", 42, nil, "other"}.each do |value|
+          expected = t1.has_key?(key) && t1[key] == value
+          t1.has_entry?(key, value).should eq(expected)
+        end
+      end
+    end
+  end
+
   it "overwrites a same-type fixed-size value in place without resizing" do
     t1 = AMQ::Protocol::Table.new({"a": 1i64, "b": "tail"})
     bytesize_before = t1.bytesize

--- a/src/amq/protocol/table.cr
+++ b/src/amq/protocol/table.cr
@@ -75,6 +75,37 @@ module AMQ
         has_key?(key.to_s)
       end
 
+      # Returns true if the table contains *key* and its value equals *value*.
+      # Semantically identical to `has_key?(key) && self[key] == value` but
+      # does not allocate for scalar and string values.
+      def has_entry?(key : String, value : Field) : Bool
+        with_pos_loop do |pos|
+          if key_matches?(pos, key.to_slice)
+            return field_equals?(pos, value)
+          else
+            skip_field(pos)
+          end
+        end
+        false
+      end
+
+      # Compares the field at *pos* with *value* without materializing a
+      # String when both are strings; other types fall back to `read_field`.
+      private def field_equals?(pos : Int32*, value : Field) : Bool
+        if value.is_a?(String)
+          ensure_available(pos.value, 1)
+          if 'S' === @buffer[pos.value]
+            pos.value += 1
+            sz = BYTEFORMAT.decode(UInt32, to_slice(pos.value, sizeof(UInt32)))
+            pos.value += sizeof(UInt32)
+            stored = to_slice(pos.value, sz)
+            pos.value += sz
+            return value.to_slice == stored
+          end
+        end
+        read_field(pos) == value
+      end
+
       def each(& : (String, Field) -> _)
         with_pos_loop do |pos|
           k = read_short_string(pos)


### PR DESCRIPTION
## What

Adds `Table#has_entry?(key, value)` — semantically identical to `has_key?(key) && self[key] == value`, but it compares stored string fields byte-wise against the expected String without materializing one. Scalar fields already decode without heap allocation; complex values (nested tables, arrays, bytes, time) fall back to `read_field`. On duplicate keys it compares against the first occurrence, matching `fetch` semantics.

## Why

LavinMQ's headers exchange compares binding arguments against message headers for every published message. The `has_key? && [] ==` pattern allocates 32 bytes per string comparison on that hot path. With this method the comparison is allocation-free (measured with `GC.stats.total_bytes`, 100k iterations, release build):

| Operation | bytes/op |
|---|---:|
| `has_entry?` string value (equal / unequal) | 0 |
| `has_entry?` int value, incl. Int64-stored vs Int32-expected | 0 |
| `has_key? && [] ==` string value (old pattern) | 32 |

Used by cloudamqp/lavinmq#2045, which vendors this method until it's available in a release.

## Verification

- New specs: equality across scalar types (string/int/bool/nil/float), unequal values, absent key, cross-numeric-type equality, type mismatches (string vs int, bytes vs string), nested-table fallback, duplicate-key first-occurrence (degenerate buffer built by concatenating two encoded tables), and an exhaustive equivalence sweep against `has_key? && [] ==`.
- Full suite with CI flags (`--order random -Dpreview_mt -Dexecution_context`): 71 examples, 0 failures.
- `crystal tool format --check` and ameba clean.

https://claude.ai/code/session_01Kn8ZEerVfMmTt59QR4duBQ